### PR TITLE
Disabled button and tooltip bugfix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ampel-ui",
-  "version": "0.18.2",
+  "version": "0.19.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/table/table.less
+++ b/src/table/table.less
@@ -16,6 +16,7 @@
         &[disabled] {
             color: @gray-light;
             cursor: not-allowed;
+            pointer-events: none;
         }
 
         &:hover:not([disabled]) {
@@ -178,15 +179,14 @@
         }
     }
 
-    .action-button {
-        @icon-button-defaults();
-        padding: 0;
-        width: 15px;
-        height: 15px;
+    .action-button-wrapper {
         margin-right: 8px;
 
-        &:disabled {
-            pointer-events: none;
+        .action-button {
+            @icon-button-defaults();
+            width: 15px;
+            height: 15px;
+            padding: 0;
         }
 
         &:before {

--- a/src/table/table.less
+++ b/src/table/table.less
@@ -194,6 +194,12 @@
             width: 15px;
             height: 15px;
         }
+
+        &--disabled {
+            &:hover {
+                cursor: not-allowed;
+            }
+        }
     }
 
     .table-header {

--- a/src/table/table.less
+++ b/src/table/table.less
@@ -185,6 +185,10 @@
         height: 15px;
         margin-right: 8px;
 
+        &:disabled {
+            pointer-events: none;
+        }
+
         &:before {
             display: block;
             width: 15px;

--- a/src/table/table.tsx
+++ b/src/table/table.tsx
@@ -222,7 +222,7 @@ class Table<ROW> extends React.Component<Props<ROW>, State> {
             button
         ) : (
             <Tooltip key={action.id} text={action.tooltip} placement="top">
-                {button}
+                <div>{button}</div>
             </Tooltip>
         );
     }

--- a/src/table/table.tsx
+++ b/src/table/table.tsx
@@ -210,9 +210,11 @@ class Table<ROW> extends React.Component<Props<ROW>, State> {
         const onClick = () => action.onClick(row);
         const disabled = typeof action.disabled === 'function' ? action.disabled(row) : action.disabled;
         const button = (
-            <div className={`action-button-wrapper ${disabled ? 'action-button-wrapper--disabled' : ''}`}>
+            <div
+                key={action.id}
+                className={`action-button-wrapper ${disabled ? 'action-button-wrapper--disabled' : ''}`}
+            >
                 <button
-                    key={action.id}
                     type="button"
                     onClick={onClick}
                     data-qa={`table--row-${cellProps.index}-col-_actions--${action.id}`}

--- a/src/table/table.tsx
+++ b/src/table/table.tsx
@@ -209,20 +209,22 @@ class Table<ROW> extends React.Component<Props<ROW>, State> {
         const row = cellProps.original;
         const onClick = () => action.onClick(row);
         const button = (
-            <button
-                key={action.id}
-                type="button"
-                onClick={onClick}
-                data-qa={`table--row-${cellProps.index}-col-_actions--${action.id}`}
-                disabled={typeof action.disabled === 'function' ? action.disabled(row) : action.disabled}
-                className={`action-button ${action.iconClass} ${this.getVisibleClass(action, row)}`}
-            />
+            <div className="action-button-wrapper">
+                <button
+                    key={action.id}
+                    type="button"
+                    onClick={onClick}
+                    data-qa={`table--row-${cellProps.index}-col-_actions--${action.id}`}
+                    disabled={typeof action.disabled === 'function' ? action.disabled(row) : action.disabled}
+                    className={`action-button ${action.iconClass} ${this.getVisibleClass(action, row)}`}
+                />
+            </div>
         );
         return !action.tooltip ? (
             button
         ) : (
             <Tooltip key={action.id} text={action.tooltip} placement="top">
-                <div>{button}</div>
+                {button}
             </Tooltip>
         );
     }

--- a/src/table/table.tsx
+++ b/src/table/table.tsx
@@ -208,14 +208,15 @@ class Table<ROW> extends React.Component<Props<ROW>, State> {
     private getActionComponent(action: TableAction<ROW>, cellProps: any) {
         const row = cellProps.original;
         const onClick = () => action.onClick(row);
+        const disabled = typeof action.disabled === 'function' ? action.disabled(row) : action.disabled;
         const button = (
-            <div className="action-button-wrapper">
+            <div className={`action-button-wrapper ${disabled ? 'action-button-wrapper--disabled' : ''}`}>
                 <button
                     key={action.id}
                     type="button"
                     onClick={onClick}
                     data-qa={`table--row-${cellProps.index}-col-_actions--${action.id}`}
-                    disabled={typeof action.disabled === 'function' ? action.disabled(row) : action.disabled}
+                    disabled={disabled}
                     className={`action-button ${action.iconClass} ${this.getVisibleClass(action, row)}`}
                 />
             </div>


### PR DESCRIPTION
Tooltip does not disappear If it has a trigger element that contains a disabled prop. That's a most likely bug in the underlying component we are using.

A simple workaround for this case is to wrap tooltip trigger in a div and add `pointer-events: none` property to the disabled element.