### PR TITLE
change tooltip dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ampel-ui",
-  "version": "0.20.5",
+  "version": "0.20.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2015,6 +2015,15 @@
         "sha.js": "^2.4.8"
       }
     },
+    "create-react-context": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.3.0.tgz",
+      "integrity": "sha512-dNldIoSuNSvlTJ7slIKC/ZFGKexBMBrrcc+TTe1NdmROnaASuLPvqpwj9v4XS4uXZ8+YPu0sNmShX2rXI5LNsw==",
+      "requires": {
+        "gud": "^1.0.0",
+        "warning": "^4.0.3"
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -2341,6 +2350,19 @@
       "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
       "dev": true
     },
+    "deep-equal": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
+      "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+      "requires": {
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.1",
+        "is-regex": "^1.0.4",
+        "object-is": "^1.0.1",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.2.0"
+      }
+    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -2351,7 +2373,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "dev": true,
       "requires": {
         "object-keys": "^1.0.12"
       }
@@ -2664,7 +2685,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
       "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-      "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -3187,7 +3207,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3208,12 +3229,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3228,17 +3251,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3355,7 +3381,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3367,6 +3394,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3381,6 +3409,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3388,12 +3417,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3412,6 +3443,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3492,7 +3524,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3504,6 +3537,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3589,7 +3623,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3625,6 +3660,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3644,6 +3680,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3687,20 +3724,21 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "g-status": {
       "version": "2.0.2",
@@ -3864,6 +3902,11 @@
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
       "dev": true
     },
+    "gud": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
+      "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
+    },
     "handlebars": {
       "version": "4.5.3",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
@@ -3896,7 +3939,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -3927,8 +3969,7 @@
     "has-symbols": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-      "dev": true
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
     },
     "has-value": {
       "version": "1.0.0",
@@ -4268,6 +4309,11 @@
         }
       }
     },
+    "is-arguments": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
+      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA=="
+    },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -4292,8 +4338,7 @@
     "is-callable": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
-      "dev": true
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
     },
     "is-ci": {
       "version": "2.0.0",
@@ -4341,8 +4386,7 @@
     "is-date-object": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
-      "dev": true
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
     },
     "is-descriptor": {
       "version": "0.1.6",
@@ -4480,7 +4524,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-      "dev": true,
       "requires": {
         "has": "^1.0.1"
       }
@@ -4516,7 +4559,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
       "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
-      "dev": true,
       "requires": {
         "has-symbols": "^1.0.1"
       }
@@ -6175,14 +6217,17 @@
     "object-inspect": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
-      "dev": true
+      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
+    },
+    "object-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.2.tgz",
+      "integrity": "sha512-Epah+btZd5wrrfjkJZq1AOB9O6OxUQto45hzFd7lXGrpHPGE0W1k+426yrZV+k6NJOzLNNW/nVsmZdIWsAqoOQ=="
     },
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
     },
     "object-visit": {
       "version": "1.0.1",
@@ -6197,7 +6242,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
       "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
         "function-bind": "^1.1.1",
@@ -6593,6 +6637,11 @@
       "resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
       "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
       "dev": true
+    },
+    "popper.js": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
+      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
     },
     "posix-character-classes": {
       "version": "0.1.1",
@@ -7499,6 +7548,29 @@
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
+    "react-popper": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.7.tgz",
+      "integrity": "sha512-nmqYTx7QVjCm3WUZLeuOomna138R1luC4EqkW3hxJUrAe+3eNz3oFCLYdnPwILfn0mX1Ew2c3wctrjlUMYYUww==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "create-react-context": "^0.3.0",
+        "deep-equal": "^1.1.1",
+        "popper.js": "^1.14.4",
+        "prop-types": "^15.6.1",
+        "typed-styles": "^0.0.7",
+        "warning": "^4.0.2"
+      }
+    },
+    "react-popper-tooltip": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/react-popper-tooltip/-/react-popper-tooltip-2.10.1.tgz",
+      "integrity": "sha512-cib8bKiyYcrIlHo9zXx81G0XvARfL8Jt+xum709MFCgQa3HTqTi4au3iJ9tm7vi7WU7ngnqbpWkMinBOtwo+IQ==",
+      "requires": {
+        "@babel/runtime": "^7.7.4",
+        "react-popper": "^1.3.6"
+      }
+    },
     "react-table": {
       "version": "6.8.6",
       "resolved": "https://registry.npmjs.org/react-table/-/react-table-6.8.6.tgz",
@@ -7614,6 +7686,66 @@
       "requires": {
         "extend-shallow": "^3.0.2",
         "safe-regex": "^1.1.0"
+      }
+    },
+    "regexp.prototype.flags": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
+      "integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.5",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
+          "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.1.5",
+            "is-regex": "^1.0.5",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimleft": "^2.1.1",
+            "string.prototype.trimright": "^2.1.1"
+          }
+        },
+        "is-callable": {
+          "version": "1.1.5",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
+          "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q=="
+        },
+        "is-regex": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+          "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+          "requires": {
+            "has": "^1.0.3"
+          }
+        },
+        "string.prototype.trimleft": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
+          "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
+          "requires": {
+            "define-properties": "^1.1.3",
+            "function-bind": "^1.1.1"
+          }
+        },
+        "string.prototype.trimright": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
+          "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
+          "requires": {
+            "define-properties": "^1.1.3",
+            "function-bind": "^1.1.1"
+          }
+        }
       }
     },
     "remove-trailing-separator": {
@@ -8908,6 +9040,11 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
       "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
       "dev": true
+    },
+    "typed-styles": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/typed-styles/-/typed-styles-0.0.7.tgz",
+      "integrity": "sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q=="
     },
     "typedarray": {
       "version": "0.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ampel-ui",
-  "version": "0.20.9",
+  "version": "0.20.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -67,13 +67,12 @@
   "dependencies": {
     "@types/lodash": "~4.14.136",
     "@types/rc-slider": "8.6.3",
-    "@types/rc-tooltip": "~3.7.1",
     "@types/react-table": "~6.7.15",
     "@types/yup": "~0.26.12",
     "immutability-helper": "~3.0.0",
     "lodash": "~4.17.15",
     "rc-slider": "8.6.7",
-    "rc-tooltip": "~3.7.3",
+    "react-popper-tooltip": "^2.10.1",
     "react-table": "~6.8.6",
     "yup": "~0.27.0"
   },

--- a/src/tooltip/tooltip.less
+++ b/src/tooltip/tooltip.less
@@ -24,7 +24,7 @@
 }
 
 .tooltip-container-bottom {
-    margin: 2.41rem;
+    margin-top: 1rem;
 }
 
 .tooltip-container-left {

--- a/src/tooltip/tooltip.less
+++ b/src/tooltip/tooltip.less
@@ -1,145 +1,145 @@
-@tooltip-prefix-cls: rc-tooltip;
-
-@font-size-base: 12px;
-@line-height-base: 1.5;
-@border-radius-base: 6px;
-@overlay-shadow: 0 0 4px rgba(0, 0, 0, 0.17);
+@font-size-base: 14px;
 @tooltip-color: @white;
-@tooltip-bg: @gray-coal;
-
-@tooltip-arrow-width: 5px;
-@tooltip-distance: (@tooltip-arrow-width + 4px);
+@tooltip-bg: @gray-lighter;
 @tooltip-arrow-color: @tooltip-bg;
 
-.@{tooltip-prefix-cls} {
-    position: absolute;
-    z-index: 1070;
-    display: block;
-    font-size: @font-size-base;
-    line-height: @line-height-base;
+@tooltip-arrow-background-after: @tooltip-bg;
+@tooltip-arrow-background-before: @gray-mid-light;
 
-    max-width: 300px;
-
-    &-hidden {
-        display: none;
-    }
-
-    &-placement-top, &-placement-topLeft, &-placement-topRight {
-        padding: @tooltip-arrow-width 0 @tooltip-distance 0;
-    }
-    &-placement-right, &-placement-rightTop, &-placement-rightBottom {
-        padding: 0 @tooltip-arrow-width 0 @tooltip-distance;
-    }
-    &-placement-bottom, &-placement-bottomLeft, &-placement-bottomRight {
-        padding: @tooltip-distance 0 @tooltip-arrow-width 0;
-    }
-    &-placement-left, &-placement-leftTop, &-placement-leftBottom {
-        padding: 0 @tooltip-distance 0 @tooltip-arrow-width;
-    }
-}
-
-.@{tooltip-prefix-cls}-inner {
-    padding: 8px 10px;
-    color: @tooltip-color;
-    text-align: left;
-    text-decoration: none;
+.tooltip-container {
     background-color: @tooltip-bg;
-    border-radius: @border-radius-base;
-    box-shadow: @overlay-shadow;
+    border-radius: 0px;
+    font-size: @font-size-base;
+    padding: 10px 16px;
+    border: 1px solid @gray-mid;
+    box-shadow: 0 2px 4px @gray-mid;
+    display: flex;
+    flex-direction: column;
+    transition: opacity 0.3s;
+    z-index: 2147483647;
 }
 
-.@{tooltip-prefix-cls}-arrow {
+.tooltip-container-top {
+    margin-bottom: 1rem;
+}
+
+.tooltip-container-bottom {
+    margin: 2.41rem;
+}
+
+.tooltip-container-left {
+    margin-right: 1.5rem;
+}
+
+.tooltip-arrow-top,
+.tooltip-arrow-bottom {
+    margin-left: -1.5rem;
+}
+
+.tooltip-arrow-right,
+.tooltip-arrow-left {
+    margin-top: -0.4rem;
+}
+
+.tooltip-arrow {
+    height: 1rem;
+    position: absolute;
+    width: 1rem;
+}
+
+.tooltip-arrow::before {
+    border-style: solid;
+    content: '';
+    display: block;
+    height: 0;
+    margin: auto;
+    width: 0;
+}
+
+.tooltip-arrow::after {
+    border-style: solid;
+    content: '';
+    display: block;
+    height: 0;
+    margin: auto;
     position: absolute;
     width: 0;
-    height: 0;
-    border-color: transparent;
-    border-style: solid;
 }
 
-.@{tooltip-prefix-cls} {
-    &-placement-top &-arrow,
-    &-placement-topLeft &-arrow,
-    &-placement-topRight &-arrow {
-        bottom: (@tooltip-distance - @tooltip-arrow-width);
-        margin-left: -@tooltip-arrow-width;
-        border-width: @tooltip-arrow-width @tooltip-arrow-width 0;
-        border-top-color: @tooltip-arrow-color;
-    }
+.tooltip-arrow[data-placement*='bottom'] {
+    height: 1rem;
+    left: 0;
+    margin-top: -1rem;
+    top: 0;
+    width: 1rem;
+}
 
-    &-placement-top &-arrow {
-        left: 50%;
-    }
+.tooltip-arrow[data-placement*='bottom']::before {
+    border-color: transparent transparent @tooltip-arrow-background-before transparent;
+    border-width: 0 1rem 1rem 1rem;
+    position: absolute;
+}
 
-    &-placement-topLeft &-arrow {
-        left: 15%;
-    }
+.tooltip-arrow[data-placement*='bottom']::after {
+    border-color: transparent transparent @tooltip-arrow-background-after transparent;
+    border-width: 0 1rem 1rem 1rem;
+    top: 1px;
+}
 
-    &-placement-topRight &-arrow {
-        right: 15%;
-    }
+.tooltip-arrow[data-placement*='top'] {
+    bottom: 0;
+    height: 1rem;
+    left: 0;
+    margin-bottom: -1rem;
+    width: 1rem;
+}
 
-    &-placement-right &-arrow,
-    &-placement-rightTop &-arrow,
-    &-placement-rightBottom &-arrow {
-        left: (@tooltip-distance - @tooltip-arrow-width);
-        margin-top: -@tooltip-arrow-width;
-        border-width: @tooltip-arrow-width @tooltip-arrow-width @tooltip-arrow-width 0;
-        border-right-color: @tooltip-arrow-color;
-    }
+.tooltip-arrow[data-placement*='top']::before {
+    border-color: @tooltip-arrow-background-before transparent transparent transparent;
+    border-width: 1rem 1rem 0 1rem;
+    position: absolute;
+    top: 1px;
+}
 
-    &-placement-right &-arrow {
-        top: 50%;
-    }
+.tooltip-arrow[data-placement*='top']::after {
+    border-color: @tooltip-bg transparent transparent transparent;
+    border-width: 1rem 1rem 0 1rem;
+}
 
-    &-placement-rightTop &-arrow {
-        top: 15%;
-        margin-top: 0;
-    }
+.tooltip-arrow[data-placement*='right'] {
+    height: 1rem;
+    left: 0;
+    margin-left: -0.8rem;
+    width: 1rem;
+}
 
-    &-placement-rightBottom &-arrow {
-        bottom: 15%;
-    }
+.tooltip-arrow[data-placement*='right']::before {
+    border-color: transparent @tooltip-arrow-background-before transparent transparent;
+    border-width: 0.8rem 0.8rem 0.8rem 0;
+    position: absolute;
+}
 
-    &-placement-left &-arrow,
-    &-placement-leftTop &-arrow,
-    &-placement-leftBottom &-arrow {
-        right: (@tooltip-distance - @tooltip-arrow-width);
-        margin-top: -@tooltip-arrow-width;
-        border-width: @tooltip-arrow-width 0 @tooltip-arrow-width @tooltip-arrow-width;
-        border-left-color: @tooltip-arrow-color;
-    }
+.tooltip-arrow[data-placement*='right']::after {
+    border-color: transparent @tooltip-arrow-background-after transparent transparent;
+    border-width: 0.8rem 0.8rem 0.8rem 0;
+    left: 1px;
+}
 
-    &-placement-left &-arrow {
-        top: 50%;
-    }
+.tooltip-arrow[data-placement*='left'] {
+    height: 1rem;
+    margin-right: -0.8rem;
+    right: 0;
+    width: 1rem;
+}
 
-    &-placement-leftTop &-arrow {
-        top: 15%;
-        margin-top: 0;
-    }
+.tooltip-arrow[data-placement*='left']::before {
+    border-color: transparent transparent transparent @tooltip-arrow-background-before;
+    border-width: 0.8rem 0 0.8rem 0.8rem;
+    position: absolute;
+    right: 1px;
+}
 
-    &-placement-leftBottom &-arrow {
-        bottom: 15%;
-    }
-
-    &-placement-bottom &-arrow,
-    &-placement-bottomLeft &-arrow,
-    &-placement-bottomRight &-arrow {
-        top: (@tooltip-distance - @tooltip-arrow-width);
-        margin-left: -@tooltip-arrow-width;
-        border-width: 0 @tooltip-arrow-width @tooltip-arrow-width;
-        border-bottom-color: @tooltip-arrow-color;
-    }
-
-    &-placement-bottom &-arrow {
-        left: 50%;
-    }
-
-    &-placement-bottomLeft &-arrow {
-        left: 15%;
-    }
-
-    &-placement-bottomRight &-arrow {
-        right: 15%;
-    }
+.tooltip-arrow[data-placement*='left']::after {
+    border-color: transparent transparent transparent @tooltip-arrow-background-after;
+    border-width: 0.8rem 0 0.8rem 0.8rem;
 }

--- a/src/tooltip/tooltip.tsx
+++ b/src/tooltip/tooltip.tsx
@@ -1,25 +1,73 @@
 import * as React from 'react';
 
-import RcTooltip from 'rc-tooltip';
+import TooltipTrigger from 'react-popper-tooltip';
+import { TooltipArg, Trigger } from 'react-popper-tooltip/dist/types';
+
+import PopperJS from 'popper.js';
 
 interface Props {
     text?: string;
     placement?: string;
 }
 
+interface ArrowProps {
+    tooltip?: string;
+    hideArrow?: boolean;
+}
+
+type TooltipTriggerAndArrowProps = ArrowProps & {
+    placement: any;
+    trigger: Trigger;
+    children: any;
+};
+
+const getTooltip = ({ tooltip, hideArrow }: ArrowProps) => ({
+    arrowRef,
+    tooltipRef,
+    getArrowProps,
+    getTooltipProps,
+    placement,
+}: TooltipArg) => (
+    <div
+        {...getTooltipProps({
+            ref: tooltipRef,
+            className: `tooltip-container tooltip-container-${placement}`,
+        })}
+    >
+        {!hideArrow && (
+            <div
+                {...getArrowProps({
+                    ref: arrowRef,
+                    className: `tooltip-arrow tooltip-arrow-${placement}`,
+                    'data-placement': placement,
+                })}
+            />
+        )}
+        {tooltip}
+    </div>
+);
+
+const TooltipCom = ({ children, tooltip, hideArrow, ...props }: TooltipTriggerAndArrowProps) => (
+    <TooltipTrigger {...props} tooltip={getTooltip({ tooltip, hideArrow })}>
+        {({ getTriggerProps, triggerRef }) => (
+            <span
+                {...getTriggerProps({
+                    ref: triggerRef,
+                    className: 'trigger',
+                })}
+            >
+                {children}
+            </span>
+        )}
+    </TooltipTrigger>
+);
 const Tooltip: React.FunctionComponent<Props> = (props) => {
     return !props.text ? (
         <>{props.children}</>
     ) : (
-        <RcTooltip
-            overlay={props.text}
-            trigger={['hover']}
-            placement={props.placement || 'top'}
-            mouseLeaveDelay={0}
-            destroyTooltipOnHide={true}
-        >
+        <TooltipCom placement={(props.placement || 'top') as PopperJS.Placement} trigger={'hover'} tooltip={props.text}>
             {props.children}
-        </RcTooltip>
+        </TooltipCom>
     );
 };
 

--- a/src/variables.less
+++ b/src/variables.less
@@ -4,6 +4,7 @@
 @gray-lighter: #F3F3F3;
 @gray-light: #E7E7E7;
 @gray-mid: #D7D7D7;
+@gray-mid-light: #00000029;
 @gray-dark: #C3C3C3;
 @gray-darker: #888888;
 @gray-darkest: #58585A;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,7 +32,7 @@ module.exports = {
     },
     module: {
         rules: [
-            { test: /\.tsx?$/, loader: 'awesome-typescript-loader'},
+            { test: /\.tsx?$/, loader: 'awesome-typescript-loader' },
             {
                 test: /\.less$/,
                 use: [
@@ -80,9 +80,8 @@ module.exports = {
         'classnames': 'classNames',
         'lodash': 'lodash',
         'yup': 'yup',
-        'rc-tooltip': 'rc-tooltip',
+        'react-popper-tooltip': 'react-popper-tooltip',
         'rc-slider': 'rc-slider',
         'immutability-helper': 'immutability-helper'
-
     }
 };


### PR DESCRIPTION
According to the new design requirements:
- Increase the font size
- Increase the arrow size
- increase the padding

The previous library `rc-tooltip` was not able to adjust the arrow correctly, so I had to change the dependency to `react-popper-tooltip` which provide more options to the customization, as well as it has option to detect the placement automatically.