### PR TITLE
Change trigger classname

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ampel-ui",
-  "version": "0.20.12",
+  "version": "0.20.13",
   "description": "Ampel UI is a UI component framework written for TypeScript + React",
   "main": "./dist/bundle.js",
   "types": "./dist/src/index.d.ts",

--- a/src/tooltip/tooltip.tsx
+++ b/src/tooltip/tooltip.tsx
@@ -53,7 +53,7 @@ const TooltipCom = ({ children, tooltip, hideArrow, ...props }: TooltipTriggerAn
             <span
                 {...getTriggerProps({
                     ref: triggerRef,
-                    className: 'trigger',
+                    className: 'tooltip-trigger',
                 })}
             >
                 {children}


### PR DESCRIPTION
Change trigger classname to tooltip-trigger to avoid css class names conflicts.