### PR TITLE
Fix Icon size on safari browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ampel-ui",
-  "version": "0.20.16",
+  "version": "0.20.17",
   "description": "Ampel UI is a UI component framework written for TypeScript + React",
   "main": "./dist/bundle.js",
   "types": "./dist/src/index.d.ts",

--- a/src/table/table.less
+++ b/src/table/table.less
@@ -181,12 +181,12 @@
     }
 
     .action-button-wrapper {
-        margin-right: 10px;
-        margin-left: 10px;
+        margin-right: 8px;
+        margin-left: 8px;
 
         .action-button {
             @icon-button-defaults();
-            width: 20px;
+            width: 24px;
             height: 40px;
             font-size: 24px;
             padding: 0;


### PR DESCRIPTION
Safari browser is not rendering the actions buttons on the tables as expected, the icons are cut from the edge somehow, the reason is because the font size was bigger than the width and safari is making the priorities to the width in contrast with Chrome and Mozilla, so I had to change the numbers according to Safari with will run perfectly cross all the browsers.